### PR TITLE
Tbl 050/rabbit mq

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -1,0 +1,5 @@
+.build
+.build-test
+.idea
+__pycache__
+.git

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ implementations to specific versions of this library.
   extracting information (such as a list of endpoints) and re-writing parts of the file, for example to re-point
   the 'host' component.
 
+* ons_rabbit
+
+  This is a wrapper for RabbitMQ connections and works with the Cloud Foundry module to detect whether there is a
+  Rabbit Queue available, and if there is, makes the credentials available as properties. i.e. if you have a queue
+  installed you should have **onv_env.rabbit.**{*host,port,name,username,password*}. Alternatively you can put
+  local defaults in your config.ini using **rabbit_**{*host,port,name,username,password*}. See the **development**
+  section in this repo's config.ini for an example.
+
 #### How to use this code
 
 To set up a new Micro-Service you need the following lines of code;

--- a/config.ini
+++ b/config.ini
@@ -90,6 +90,12 @@ log_level = DEBUG
 authentication = false
 db_connection = ${db_driver}://${db_user}:${db_pass}@${db_host}:${db_port}/${db_name}
 db_schema = ras
+debug = true
+rabbit_name = local_rabbit
+rabbit_host = localhost
+rabbit_port = 1234
+rabbit_username = onsdigital
+rabbit_password = 5678
 
 [demo]
 api_gateway = api-demo.apps.mvp.onsclofo.uk
@@ -100,6 +106,7 @@ db_service = ras-postgres
 api_gateway = api-dev.apps.mvp.onsclofo.uk
 protocol = https
 db_service = ras-postgres
+debug = true
 
 [int]
 api_gateway = api-int.apps.mvp.onsclofo.uk

--- a/config.ini
+++ b/config.ini
@@ -63,6 +63,7 @@ db_service = ras-postgres
 ;
 debug = false
 log_level = INFO
+log_format = json
 authentication = true
 ;
 ;   Encryption settings, for production purposes all these settings need to be
@@ -93,9 +94,10 @@ db_schema = ras
 debug = true
 rabbit_name = local_rabbit
 rabbit_host = localhost
-rabbit_port = 1234
-rabbit_username = onsdigital
-rabbit_password = 5678
+rabbit_port = 15672
+rabbit_username = guest
+rabbit_password = guest
+log_format = text
 
 [demo]
 api_gateway = api-demo.apps.mvp.onsclofo.uk

--- a/local.ini
+++ b/local.ini
@@ -9,6 +9,6 @@
 ;   put environment specific settings here.
 ;
 [microservice]
-my_name = My Micro-Service Name
-my_ident = Skeleton
+my_name = Common library code
+my_ident = ras-common 
 swagger = swagger.yaml

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.82'
+__version__ = '0.1.83'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.83'
+__version__ = '0.1.84'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/ons_cloudfoundry.py
+++ b/ons_ras_common/ons_cloudfoundry.py
@@ -13,6 +13,7 @@
 from os import getenv
 from json import loads
 
+
 class ONSCloudFoundry(object):
     """
 
@@ -40,26 +41,38 @@ class ONSCloudFoundry(object):
         #
         vcap_application = loads(vcap_application)
         url = vcap_application.get('application_uris', [''])[0]
-        #self._env.host = url.split(':')[0]
 
         if self._env.get('flask_private', 'false').lower() not in ['yes', 'true']:
             self._env.flask_host = url.split(':')[0]
             self._env.flask_port = 443
             self._env.flask_protocol = 'https'
-            self._env.logger.info('Setting host to "{}" and port to "{}"'.format(self._env.api_host, self._env.api_port))
+            self.info('Setting host to "{}" and port to "{}"'.format(self._env.api_host, self._env.api_port))
         #
         #   Now get our database connection (if there is one)
         #
         vcap_services = getenv('VCAP_SERVICES')
+        vcap_services = loads(vcap_services)
         if not vcap_services:
             return self.log('Services: No services detected')
-        for areas in loads(vcap_services).values():
-            for service in areas:
+        for key, services in vcap_services.items():
+            if key == 'rds':
                 credentials = service.get('credentials', {})
                 self._env.set('db_connection', credentials.get('uri',''))
                 self._env.set('db_connection_name', service.get('name', ''))
-                self.info('DB Connection String: {}'.format(credentials['uri']))
-                self.info('DB Connection Name..: {}'.format(service['name']))
+                self.info('Detected service "{}"'.format(service.get('name', '')))
+
+            if key == 'rabbitmq':
+                for service in services:
+                    amqp = service.get('credentials', {}).get('protocols', {}).get('amqp', None)
+                    if amqp:
+                        self._env.rabbit.add_service({
+                            'host': amqp.get('host', 'no host'),
+                            'port': amqp.get('port', 'no port'),
+                            'username': amqp.get('username', 'no username'),
+                            'password': amqp.get('password', 'no password'),
+                            'name': service.get('name', 'no name')
+                        })
+                    self.info('Detected service "{}"'.format(service.get('name', '')))
 
     @property
     def detected(self):

--- a/ons_ras_common/ons_database.py
+++ b/ons_ras_common/ons_database.py
@@ -38,13 +38,14 @@ class ONSDatabase(object):
     def session(self):
         return self._session
 
-    def info(self, text):
-        self._env.logger.info('[db] {}'.format(text))
-
     def warn(self, text):
-        self._env.logger.warn('[db] [warning] {}'.format(text))
+        self._env.logger.warn(text, module=__name__)
+
+    def info(self, text):
+        self._env.logger.info(text, module=__name__)
 
     def activate(self):
+
         if self._env.get('enable_database', 'false').lower() not in ['true', 'yes']:
             return self.info('Database is NOT enabled [missing "enabled_database = true"]')
 

--- a/ons_ras_common/ons_environment.py
+++ b/ons_ras_common/ons_environment.py
@@ -91,6 +91,8 @@ class ONSEnvironment(object):
         """
         self.setup()
         self._registration.activate()
+        self.info('Acquired listening port "{}"'.format(self._port))
+
 
         if self.swagger.has_api:
             swagger_file = '{}/{}'.format(self.swagger.path, self.swagger.file)
@@ -156,7 +158,6 @@ class ONSEnvironment(object):
         sock.bind(('localhost', 0))
         _, port = sock.getsockname()
         sock.close()
-        self.info('Acquired listening port "{}"'.format(port))
         return port
 
     @property

--- a/ons_ras_common/ons_environment.py
+++ b/ons_ras_common/ons_environment.py
@@ -29,6 +29,7 @@ from .ons_jwt import ONSJwt
 from .ons_swagger import ONSSwagger
 from .ons_cryptographer import ONSCryptographer
 from .ons_registration import ONSRegistration
+from .ons_rabbit import ONSRabbit
 from socket import socket, AF_INET, SOCK_STREAM
 from pathlib import Path
 from os import getcwd
@@ -47,7 +48,7 @@ class ONSEnvironment(object):
         self._port = None
         self._host = None
         self._gateway = None
-
+        self._debug = None
         self.api_protocol = None
         self.api_host = None
         self.api_port = None
@@ -60,6 +61,7 @@ class ONSEnvironment(object):
         self._env = getenv('ONS_ENV', 'development')
         self._logger = ONSLogger(self)
         self._database = ONSDatabase(self)
+        self._rabbit = ONSRabbit(self)
         self._cloudfoundry = ONSCloudFoundry(self)
         self._swagger = ONSSwagger(self)
         self._jwt = ONSJwt(self)
@@ -81,6 +83,7 @@ class ONSEnvironment(object):
         self._swagger.activate()
         self._jwt.activate()
         self._cryptography.activate()
+        self._rabbit.activate()
 
     def activate(self, callback=None):
         """
@@ -122,6 +125,7 @@ class ONSEnvironment(object):
         self.flask_host = self.get('flask_host')
         self.flask_port = self.get('flask_port', self._port)
         self.flask_protocol = self.get('flask_protocol')
+        self._debug = self.get('debug', False).lower() in ['yes', 'true']
 
     def get(self, attribute, default=None, section=None):
         """
@@ -280,3 +284,11 @@ class ONSEnvironment(object):
     @flask_port.setter
     def flask_port(self, value):
         self._flask_port = value
+
+    @property
+    def rabbit(self):
+        return self._rabbit
+
+    @property
+    def debug(self):
+        return self._debug

--- a/ons_ras_common/ons_logger.py
+++ b/ons_ras_common/ons_logger.py
@@ -29,14 +29,15 @@ class ONSLogger(object):
     """
     def __init__(self, env):
         self._env = env
+        self._log_format = 'json'
+        self._ident = None
 
     def activate(self):
         """
         Activate the logging systems ...
         """
-        log_level = self._env.get('log_level', 'INFO')
         self._ident = self._env.get('my_ident', __name__, 'microservice')
-        self._log_format = self._env.get('log_format')
+        self._log_format = self._env.get('log_format', 'json')
         if self._log_format == 'text':
             self.logger = logging.getLogger(__name__)
         else:
@@ -45,7 +46,7 @@ class ONSLogger(object):
         logging.basicConfig(
             format="%(message)s",
             stream=sys.stdout,
-            level=LEVELS.get(log_level.lower(), logging.INFO)
+            level=LEVELS.get(self._env.get('log_level', 'INFO').lower(), logging.INFO)
         )
 
         def add_service_name(logger, method_name, event_dict):  # pylint: disable=unused-argument

--- a/ons_ras_common/ons_logger.py
+++ b/ons_ras_common/ons_logger.py
@@ -10,9 +10,17 @@
 #   to output JSON format, but for now it's a simple syslog style output.
 #
 ##############################################################################
-from twisted.python import log
-from sys import stdout
 import logging
+import datetime
+import sys
+import structlog
+import time
+
+LEVELS = {'debug': logging.DEBUG,
+          'info': logging.INFO,
+          'warning': logging.WARNING,
+          'error': logging.ERROR,
+          'critical': logging.CRITICAL}
 
 
 class ONSLogger(object):
@@ -23,30 +31,81 @@ class ONSLogger(object):
         self._env = env
 
     def activate(self):
-        logging.getLogger('twisted').setLevel(logging.ERROR)
-        logging.getLogger('werkzeug').setLevel(logging.ERROR)
-        log.startLogging(stdout)
-        self.info('[log] Logger activated [environment={}]'.format(self._env.environment))
+        """
+        Activate the logging systems ...
+        """
+        log_level = self._env.get('log_level', 'INFO')
+        self._ident = self._env.get('my_ident', __name__, 'microservice')
+        self._log_format = self._env.get('log_format')
+        if self._log_format == 'text':
+            self.logger = logging.getLogger(__name__)
+        else:
+            self.logger = structlog.get_logger(__name__)
 
-    @staticmethod
-    def info(text):
-        log.msg(text, logLevel=logging.INFO)
+        logging.basicConfig(
+            format="%(message)s",
+            stream=sys.stdout,
+            level=LEVELS.get(log_level.lower(), logging.INFO)
+        )
 
-    @staticmethod
-    def debug(text):
-        log.msg(text, logLevel=logging.DEBUG)
+        def add_service_name(logger, method_name, event_dict):  # pylint: disable=unused-argument
+            """
+            Add the service name to the event dict.
+            """
+            event_dict['service'] = self._ident
+            return event_dict
 
-    @staticmethod
-    def warn(text):
-        log.msg(text, logLevel=logging.WARN)
+        processors = [
+                structlog.processors.TimeStamper(fmt='iso'),
+                structlog.stdlib.filter_by_level,
+                add_service_name,
+                structlog.stdlib.add_log_level,
+                structlog.processors.format_exc_info,
+                structlog.processors.JSONRenderer(sort_keys=True)
+        ]
+        structlog.configure(
+            processors=processors,
+            context_class=structlog.threadlocal.wrap_dict(dict),
+            logger_factory=structlog.stdlib.LoggerFactory(),
+            wrapper_class=structlog.stdlib.BoundLogger,
+            cache_logger_on_first_use=True
+        )
+        self.info('Logger activated', environment=self._env.environment)
 
-    @staticmethod
-    def error(text):
-        log.msg(text, logLevel=logging.ERROR)
+    def info(self, *args, **kwargs):
+        if self._log_format == 'text':
+            text = '{} {}'.format(str(args).strip('()').strip(',').strip("'"), str(kwargs))
+            self.logger.info('{} {}'.format(datetime.datetime.now().isoformat(), text))
+        else:
+            self.logger.info(*args, **kwargs)
 
-    @staticmethod
-    def critical(text):
-        log.msg(text, logLevel=logging.CRITICAL)
+    def debug(self, *args, **kwargs):
+        if self._log_format == 'text':
+            text = '{} {}'.format(str(args).strip('()').strip(',').strip("'"), str(kwargs))
+            self.logger.debug('{} {}'.format(datetime.datetime.now().isoformat(), text))
+        else:
+            self.logger.debug(*args, **kwargs)
+
+    def warn(self, *args, **kwargs):
+        if self._log_format == 'text':
+            text = '{} {}'.format(str(args).strip('()').strip(',').strip("'"), str(kwargs))
+            self.logger.warning('{} {}'.format(datetime.datetime.now().isoformat(), text))
+        else:
+            self.logger.warning(*args, **kwargs)
+
+    def error(self, *args, **kwargs):
+        if self._log_format == 'text':
+            text = '{} {}'.format(str(args).strip('()').strip(',').strip("'"), str(kwargs))
+            self.logger.error('{} {}'.format(datetime.datetime.now().isoformat(), text))
+        else:
+            self.logger.error(*args, **kwargs)
+
+    def critical(self, *args, **kwargs):
+        if self._log_format == 'text':
+            text = '{} {}'.format(str(args).strip('()').strip(',').strip("'"), str(kwargs))
+            self.logger.critical('{} {}'.format(datetime.datetime.now().isoformat(), text))
+        else:
+            self.logger.critical(*args, **kwargs)
 
 #    from sys import _getframe
 #    from logging import WARN, INFO, ERROR

--- a/ons_ras_common/ons_rabbit.py
+++ b/ons_ras_common/ons_rabbit.py
@@ -1,0 +1,83 @@
+##############################################################################
+#                                                                            #
+#   ONS Digital Rabbit queue handling                                        #
+#   License: MIT                                                             #
+#   Copyright (c) 2017 Crown Copyright (Office for National Statistics)      #
+#                                                                            #
+##############################################################################
+
+
+class RabbitQueue(object):
+
+    def __init__(self, queue):
+        self.name = queue['name']
+        self.host = queue['host']
+        self.port = queue['port']
+        self.username = queue['username']
+        self.password = queue['password']
+
+
+class ONSRabbit(object):
+
+    def __init__(self, env):
+        self._env = env
+        self._queues = {}
+
+    def info(self, text):
+        self._env.logger.info('[rabbit] {}'.format(text))
+
+    def activate(self):
+        """
+        Queue activation goes here if required
+        """
+        if self._env.get('rabbit_username', None):
+            self.add_service({
+                'name': self._env.get('rabbit_name', None),
+                'host': self._env.get('rabbit_host', None),
+                'port': self._env.get('rabbit_port', None),
+                'username': self._env.get('rabbit_username', None),
+                'password': self._env.get('rabbit_password', None)
+            })
+        if not len(self._queues):
+            self.info('No Rabbit queues detected')
+            self.add_service({
+                'name': 'none',
+                'host': 'none',
+                'port': 'none',
+                'username': 'none',
+                'password': 'none'
+            })
+        if self._env.debug:
+            for queue in self._queues.values():
+                self.info('Queue "{name}" user="{username}" pass="{password}" host="{host}" port="{port}"'.format(**vars(queue)))
+
+    def add_service(self, que):
+        self._queues[que['name']] = RabbitQueue(que)
+
+    def get(self, name):
+        return self._queues.get(name, None)
+
+    @property
+    def host(self):
+        key = list(self._queues.keys())[0]
+        return self._queues[key].host
+
+    @property
+    def port(self):
+        key = list(self._queues.keys())[0]
+        return self._queues[key].port
+
+    @property
+    def name(self):
+        key = list(self._queues.keys())[0]
+        return self._queues[key].name
+
+    @property
+    def username(self):
+        key = list(self._queues.keys())[0]
+        return self._queues[key].username
+
+    @property
+    def password(self):
+        key = list(self._queues.keys())[0]
+        return self._queues[key].password

--- a/requirements.txt
+++ b/requirements.txt
@@ -43,3 +43,4 @@ urllib3==1.21.1
 Werkzeug==0.12.2
 zope.interface==4.4.1
 
+structlog==17.2.0

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.82'
+__version__ = '0.1.83'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.83'
+__version__ = '0.1.84'
 
 setup(
     name='ons_ras_common',

--- a/test/test_encryption.py
+++ b/test/test_encryption.py
@@ -6,6 +6,7 @@ class TestStringMethods(unittest.TestCase):
 
     def setUp(self):
         ons_env.setup_ini()
+        ons_env.logger.activate()
         ons_env.cipher.activate()
         self.ons_cipher = ons_env.cipher
 

--- a/test/test_jwt.py
+++ b/test/test_jwt.py
@@ -7,6 +7,7 @@ class TestStringMethods(unittest.TestCase):
 
     def setUp(self):
         ons_env.setup_ini()
+        ons_env.logger.activate()
         ons_env._jwt.activate()
         self.ons_token = ons_env.jwt
         self.now = datetime.now()


### PR DESCRIPTION
This provides rabbit detection for CF and also config.ini for local testing.

It's designed to handle multiple queues, but if you just have the one queue you should be able to access via; ons_env.rabbit.host (and port, name, username, password)

For testing against a local, queue, the same access applies, just add this to your config.ini [development] section;
rabbit_name = local_rabbit
rabbit_host = localhost
rabbit_port = 1234
rabbit_username = onsdigital
rabbit_password = 5678

(or similar)

