### PR TITLE
Adding new 'get' routine

### DIFF
--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.92'
+__version__ = '0.1.93'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/ons_environment.py
+++ b/ons_ras_common/ons_environment.py
@@ -129,7 +129,7 @@ class ONSEnvironment(object):
         self.flask_protocol = self.get('flask_protocol')
         self._debug = self.get('debug', False).lower() in ['yes', 'true']
 
-    def get(self, attribute, default=None, section=None):
+    def get(self, attribute, default=None, section=None, boolean=False):
         """
         Recover an attribute from a section in a .INI file
 
@@ -138,11 +138,16 @@ class ONSEnvironment(object):
         :param section: An optional section name, otherwise we use the environment
         :return: The value of the attribute or 'default' if not found
         """
-        if not section:
-            section = self._env
+        section = section or self._env
         if section not in self._config:
             return default
-        return self._config[section].get(attribute, default)
+
+        value = getenv(attribute.upper(), default=None)
+        if value:
+            return value
+
+        base = self._config[section]
+        return base.getboolean(attribute, default) if boolean else base.get(attribute, default)
 
     def set(self, attribute, value):
         """

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.92'
+__version__ = '0.1.93'
 
 setup(
     name='ons_ras_common',


### PR DESCRIPTION
Simple change to the environment "get" function to allow any config.ini variable to be overridden by an environment variable. i.e. it will check to see if the variable it wants is in the environment, in which case it will use it, otherwise it will fall back to the config.ini file.