### PR TITLE
Tbl074/endpoint accesss

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### Version 0.1.90
+* Before binding log context, check whether output is for JSON
+
+### Version 0.1.89
+* Add log handling for HTTP requests
+
 ### Version 0.1.82
 
 [Massive amount of refactoring and integration]

--- a/README.md
+++ b/README.md
@@ -95,8 +95,8 @@ implementations to specific versions of this library.
 
   This is a wrapper for RabbitMQ connections and works with the Cloud Foundry module to detect whether there is a
   Rabbit Queue available, and if there is, makes the credentials available as properties. i.e. if you have a queue
-  installed you should have **onv_env.rabbit.**{*host,port,name,username,password*}. Alternatively you can put
-  local defaults in your config.ini using **rabbit_**{*host,port,name,username,password*}. See the **development**
+  installed you should have **onv_env.rabbit.**{*host,port,name,username,password,vhost*}. Alternatively you can put
+  local defaults in your config.ini using **rabbit_**{*host,port,name,username,password,vhost*}. See the **development**
   section in this repo's config.ini for an example.
 
 #### How to use this code

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.88'
+__version__ = '0.1.89'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.94'
+__version__ = '0.1.95'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.91'
+__version__ = '0.1.92'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.88'
+__version__ = '0.1.90'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.89'
+__version__ = '0.1.90'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.92'
+__version__ = '0.1.93'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.93'
+__version__ = '0.1.94'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/__init__.py
+++ b/ons_ras_common/__init__.py
@@ -22,7 +22,7 @@
 ##############################################################################
 from .ons_environment import ONSEnvironment
 
-__version__ = '0.1.90'
+__version__ = '0.1.91'
 
 
 if 'ons_env' not in globals():

--- a/ons_ras_common/ons_asyncio.py
+++ b/ons_ras_common/ons_asyncio.py
@@ -1,0 +1,174 @@
+##############################################################################
+#                                                                            #
+#   Generic ASYNC IO Routines for accessing remote REST endpoints            #
+#   License: MIT                                                             #
+#   Copyright (c) 2017 Crown Copyright (Office for National Statistics)      #
+#                                                                            #
+##############################################################################
+#
+#   ONSAsyncIO wraps generic endpoint access routines
+#
+##############################################################################
+import crochet
+import treq
+from json import loads, dumps, decoder
+from twisted.internet import defer
+#
+#   How long (by default) do we wait for an endpoint call before we timeout?
+#
+DEFAULT_TIMEOUT = 3
+TYPE = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet'
+
+class ONSAsyncIO(object):
+    """
+    Provide a single point of entry for AsyncIO routines which provides a single
+    point of maintenance for future routing options, whatever they may be.
+    """
+    def __init__(self, env):
+        self._env = env
+        self._bases = None
+
+    def activate(self):
+        """
+        Set up a base URL for future access to the case service (currently via the gateway)
+        """
+        self._bases = {}
+
+    def endpoint_init(self, api, endpoint):
+        """
+        Setup an endpoint relative to a specific environment
+        """
+        self._bases[endpoint] = api
+        self._env.logger.info('[@@] Setting base for "{}" to "{}"'.format(endpoint, self._bases[endpoint]))
+
+    def get_base(self, endpoint):
+        """
+        Get a base reference for a given endpoint. Initially we're pointing at the gateway but allow
+        provision for holding direct routes to multiple micro-service, either by static routing or by
+        route discovery from the Gateway.
+
+        :param endpoint: endpoint we're about to call
+        :return: the base reference for the endpoint
+        """
+        if endpoint not in self._bases:
+            self._bases[endpoint] = '{}://{}:{}'.format(self._env.api_protocol, self._env.api_host, self._env.api_port)
+            self._env.logger.info('[++] Setting base for "{}" to "{}"'.format(endpoint, self._bases[endpoint]))
+
+        return self._bases[endpoint]
+
+    @crochet.run_in_reactor
+    def get_route(self, endpoint, params):
+        """
+        Generic routine to hit a remote endpoint. This is set to run in the twisted reactor and will
+        be called with a 'crochet' wait. So it will either return the results of the call as a Python
+        structure after decoding with JSON, or it will raise an error (or timeout error).
+
+        :param endpoint: The URL we want to hit
+        :return: The decoded results of the hit
+        """
+        def check(response):
+            """
+            Make sure the call succeeded, otherwise raise an error which will abort the pipeline
+
+            :param response: A deferred response object
+            :return: A deferred response object
+            """
+            if response.code != 200:
+                raise Exception('Call to "{}" yielded error code "{}"'.format(url, response.code))
+            return response
+
+        def json(response):
+            """
+            Decode the response (from bytes to string) then convert to a Python dict
+
+            :param response: Response object
+            :return: results as a dict
+            """
+            return loads(response.decode())
+
+        def log(failure):
+            """
+            Just log the error, a return code of 'False' will be returned elsewhere
+            :param failure: A treq failure object
+            """
+            return self._env.logger.error('[asyncio-error] {}'.format(failure.getErrorMessage()))
+
+        # Invoke a Twisted pipeline to hit the endpoint and process the results
+        url = '{}{}'.format(self.get_base(endpoint), endpoint)
+        return treq.get(url, params=params).addCallback(check).addCallback(treq.content).addCallback(json).addErrback(log)
+
+    @crochet.run_in_reactor
+    def post_route(self, endpoint, payload):
+        """
+        Generic posting routine to send data to a remote endpoint.
+
+        :param endpoint: endpoint to hit
+        :param payload: data to send
+        :return: response object
+        """
+        @defer.inlineCallbacks
+        def check(response):
+            """
+            Make sure the call succeeded, otherwise raise an error which will abort the pipeline
+
+            :param response: A deferred response object
+            :return: A deferred response object
+            """
+            msg = yield response.text()
+            msg = loads(msg)
+            if response.code > 299:
+                self._env.logger.error('[case] Failed to post event', code=response.code, reason=str(msg))
+            return response.code, msg
+
+        url = '{}{}'.format(self.get_base(endpoint), endpoint)
+        return treq.post(
+            url,
+            dumps(payload).encode('ascii'),
+            headers={b'Content-Type': [b'application/json']}
+        ).addCallback(check)
+
+    def access_endpoint(self, endpoint, params=[]):
+        """
+        Wrapper for hit_endpoint with generic error checking and reporting.
+
+        :param endpoint: The endpoint we're going to hit relative to the API base (/)
+        :return: A valid result as a python dict, or False in the case of an error
+        """
+        try:
+            result = self.get_route(endpoint, params).wait(DEFAULT_TIMEOUT)
+        except crochet.TimeoutError:
+            """The call timed out, endpoint was probably unavailable!"""
+            return self._env.logger.error('Endpoint call timed out', endpoint=endpoint)
+        except Exception as e:
+            """Unexpected error!"""
+            return self._env.logger.error('Endpoint call failed', endpoint=endpoint, error=str(e))
+        return result
+
+    @crochet.run_in_reactor
+    def post_upload(self, endpoint, case_id, upload_file):
+        """
+        """
+        def check(response):
+            """
+            Make sure the call succeeded, otherwise raise an error which will abort the pipeline
+
+            :param response: A deferred response object
+            :return: A deferred response object
+            """
+            def on_error(failure, response):
+                self._env.logger.error('error uploading file "{}"'.format(failure))
+                raise Exception('exception uploading file')
+
+            if response.code <= 299:
+                return True
+            return response.text().addCallback(on_error, response)
+
+        def fail(failure):
+            print(failure)
+            return False
+
+        url = '{}{}/{}'.format(self.get_base(endpoint), endpoint, case_id)
+        files = {'file': (upload_file.filename, upload_file.stream)}
+        headers = {b'Content-Type': [b'application/json']}
+        data = {'name': upload_file.filename, 'filename': upload_file.filename}
+        return treq.post(url, data=data, files=files, headers=headers).addCallback(check).addErrback(fail)

--- a/ons_ras_common/ons_cloudfoundry.py
+++ b/ons_ras_common/ons_cloudfoundry.py
@@ -71,6 +71,7 @@ class ONSCloudFoundry(object):
                             'port': amqp.get('port', 'no port'),
                             'username': amqp.get('username', 'no username'),
                             'password': amqp.get('password', 'no password'),
+                            'vhost': amqp.get('vhost', 'no vhost'),
                             'name': service.get('name', 'no name')
                         })
                     self.info('Detected service "{}"'.format(service.get('name', '')))

--- a/ons_ras_common/ons_decorators.py
+++ b/ons_ras_common/ons_decorators.py
@@ -36,7 +36,7 @@ def validate_jwt(scope, request):
     return authorization_required_decorator
 
 
-def __bind_request_detail_to_log(request):
+def _bind_request_detail_to_log(request):
     """
     Set up logging details for a request logger
 
@@ -48,7 +48,6 @@ def __bind_request_detail_to_log(request):
         method=request.method,
         path=request.full_path
     )
-    ons_env.logger.info("Start request")
 
 
 def before_request(request):
@@ -61,7 +60,8 @@ def before_request(request):
     def before_request_decorator(original_function):
         @wraps(original_function)
         def before_request_wrapper(*args, **kwargs):
-            __bind_request_detail_to_log(request)
+            if ons_env.logger.is_json:
+                _bind_request_detail_to_log(request)
             return original_function(*args, **kwargs)
         return before_request_wrapper
     return before_request_decorator

--- a/ons_ras_common/ons_environment.py
+++ b/ons_ras_common/ons_environment.py
@@ -129,7 +129,7 @@ class ONSEnvironment(object):
         self.flask_protocol = self.get('flask_protocol')
         self._debug = self.get('debug', False).lower() in ['yes', 'true']
 
-    def get(self, attribute, default=None, section=None):
+    def get(self, attribute, default=None, section=None, boolean=False):
         """
         Recover an attribute from a section in a .INI file
 
@@ -138,11 +138,16 @@ class ONSEnvironment(object):
         :param section: An optional section name, otherwise we use the environment
         :return: The value of the attribute or 'default' if not found
         """
-        if not section:
-            section = self._env
+        section = section or self._env
         if section not in self._config:
             return default
-        return self._config[section].get(attribute, default)
+
+        value = getenv(attribute.upper(), default=None)
+        if value:
+            return value
+
+        base = self._config[section]
+        return base.getboolean(attribute, default) if boolean else base.get(attribute, default)
 
     def set(self, attribute, value):
         """

--- a/ons_ras_common/ons_logger.py
+++ b/ons_ras_common/ons_logger.py
@@ -49,6 +49,8 @@ class ONSLogger(object):
             level=LEVELS.get(self._env.get('log_level', 'INFO').lower(), logging.INFO)
         )
 
+        self._is_json = self._log_format == 'json'
+
         def add_service_name(logger, method_name, event_dict):  # pylint: disable=unused-argument
             """
             Add the service name to the event dict.
@@ -107,6 +109,10 @@ class ONSLogger(object):
             self.logger.critical('{} {}'.format(datetime.datetime.now().isoformat(), text))
         else:
             self.logger.critical(*args, **kwargs)
+
+    @property
+    def is_json(self):
+        return self._is_json
 
 #    from sys import _getframe
 #    from logging import WARN, INFO, ERROR

--- a/ons_ras_common/ons_logger.py
+++ b/ons_ras_common/ons_logger.py
@@ -110,6 +110,13 @@ class ONSLogger(object):
         else:
             self.logger.critical(*args, **kwargs)
 
+    def exception(self, *args, **kwargs):
+        if self._log_format == 'text':
+            text = '{} {}'.format(str(args).strip('()').strip(',').strip("'"), str(kwargs))
+            self.logger.exception('{} {}'.format(datetime.datetime.now().isoformat(), text))
+        else:
+            self.logger.exception(*args, **kwargs)
+
     @property
     def is_json(self):
         return self._is_json

--- a/ons_ras_common/ons_rabbit.py
+++ b/ons_ras_common/ons_rabbit.py
@@ -37,7 +37,7 @@ class ONSRabbit(object):
                 'port': self._env.get('rabbit_port', None),
                 'username': self._env.get('rabbit_username', None),
                 'password': self._env.get('rabbit_password', None),
-                'vhost': self._env.get('rabbit_password', None)
+                'vhost': self._env.get('rabbit_vhost', None)
             })
         if not len(self._queues):
             self.info('No Rabbit queues detected')

--- a/ons_ras_common/ons_rabbit.py
+++ b/ons_ras_common/ons_rabbit.py
@@ -87,4 +87,4 @@ class ONSRabbit(object):
     @property
     def vhost(self):
         key = list(self._queues.keys())[0]
-        return self._queues[key].password
+        return self._queues[key].vhost

--- a/ons_ras_common/ons_rabbit.py
+++ b/ons_ras_common/ons_rabbit.py
@@ -36,7 +36,8 @@ class ONSRabbit(object):
                 'host': self._env.get('rabbit_host', None),
                 'port': self._env.get('rabbit_port', None),
                 'username': self._env.get('rabbit_username', None),
-                'password': self._env.get('rabbit_password', None)
+                'password': self._env.get('rabbit_password', None),
+                'vhost': self._env.get('rabbit_password', None)
             })
         if not len(self._queues):
             self.info('No Rabbit queues detected')
@@ -45,11 +46,12 @@ class ONSRabbit(object):
                 'host': 'none',
                 'port': 'none',
                 'username': 'none',
-                'password': 'none'
+                'password': 'none',
+                'vhost': 'none'
             })
         if self._env.debug:
             for queue in self._queues.values():
-                self.info('Queue "{name}" user="{username}" pass="{password}" host="{host}" port="{port}"'.format(**vars(queue)))
+                self.info('Queue "{name}" user="{username}" pass="{password}" host="{host}" port="{port}" vhost="{vhost}"'.format(**vars(queue)))
 
     def add_service(self, que):
         self._queues[que['name']] = RabbitQueue(que)
@@ -79,5 +81,10 @@ class ONSRabbit(object):
 
     @property
     def password(self):
+        key = list(self._queues.keys())[0]
+        return self._queues[key].password
+
+    @property
+    def vhost(self):
         key = list(self._queues.keys())[0]
         return self._queues[key].password

--- a/ons_ras_common/ons_rabbit.py
+++ b/ons_ras_common/ons_rabbit.py
@@ -15,7 +15,7 @@ class RabbitQueue(object):
         self.port = queue['port']
         self.username = queue['username']
         self.password = queue['password']
-
+        self.vhost = queue['vhost']
 
 class ONSRabbit(object):
 

--- a/ons_ras_common/ons_rest_case.py
+++ b/ons_ras_common/ons_rest_case.py
@@ -1,0 +1,118 @@
+##############################################################################
+#                                                                            #
+#   Generic Configuration tool for Micro-Service environment discovery       #
+#   License: MIT                                                             #
+#   Copyright (c) 2017 Crown Copyright (Office for National Statistics)      #
+#                                                                            #
+##############################################################################
+#
+#   ONSCase wraps routines used to access the case service
+#
+##############################################################################
+
+
+class ONSCase(object):
+    """
+    This class is designed to take all the work out of accessing the case service. Initially it
+    should be able to validate and log events against the case service and also query the event
+    service for specific combinations of events. (for example to determine case status)
+    """
+    def __init__(self, env):
+        self._env = env
+        self._categories = None
+
+    def activate(self):
+        """"""
+        pass
+
+    def post_event(self, case_id, description=None, category=None, party_id=None, created_by=None, payload=None):
+        """
+        Post an event to the case service ...
+
+        :param case_id: The Id if the case to post against
+        :param description: Event description
+        :param category: Event category (must be a valid category)
+        :param party_id: Party Id
+        :param created_by: Who created the event
+        :param payload: An optional event payload
+        :return: status, message
+        """
+        #
+        #   Start by making sure we were given a working data set
+        #
+        if not (description and category and party_id and created_by):
+            msg = 'description={} category={} party_id={} created_by={}'.format(
+                description, category, party_id, created_by
+            )
+            self._env.logger.error('Insufficient arguments', arguments=msg)
+            return 500, {'code': 500, 'text': 'insufficient arguments'}
+
+        #
+        #   If this is our first time, we need to acquire the current set of valid categories
+        #   form the case service in order to validate the type of the message we're going to post
+        #
+        if not self._categories:
+            self._env.logger.info('first pass :: caching event category list')
+            categories = self._env.asyncio.access_endpoint('/categories')
+            if not categories:
+                return 404, {'code': 404, 'text': 'error loading categories'}
+            self._categories = {}
+            for cat in categories:
+                action = cat.get('name')
+                if action:
+                    self._categories[action] = cat
+                else:
+                    self._env.logger.warn('received unknown category "{}"'.format(str(cat)))
+            self._env.logger.info('first pass :: cached ({}) categories'.format(len(categories)))
+
+        #
+        #   Make sure the category we have is valid
+        #
+        if category not in self._categories:
+            self._env.logger.error(error='invalid category code', category=category)
+            return 404, {'code': 404, 'text': 'invalid category code - {}'.format(category)}
+
+        #
+        #   Build a message to post
+        #
+        message = {
+            'description': description,
+            'category': category,
+            'partyId': party_id,
+            'createdBy': created_by
+        }
+        #
+        #   If we have anything in the optional payload, add it to the message
+        #
+        if payload:
+            message = dict(message, **payload)
+
+        #
+        #   Call the poster, returning the actual status and text to the caller
+        #
+        code, msg = self._env.asyncio.post_route('/cases/{}/events'.format(case_id), message).wait(2)
+        return code, msg
+
+    def get_by_id(self, case_id):
+        """
+        Recover a case by case_id
+
+        :param case_id: The case in question
+        :return: A case record
+        """
+        case = self._env.asyncio.access_endpoint('/cases/{}'.format(case_id))
+        if not case:
+            return 404, {'code': 404, 'text': 'unable to find case for this case_id'}
+
+        return 200, {'code': 200, 'case': case}
+
+    def my_surveys(self, party_id, filter):
+        """
+        Interrogate the surveys todo (aggregated endpoint) and get the data needed to build
+        the my-surveys screen.
+
+        :param party_id: The concerned party
+        :param filter: An array of statuses that we're interested in
+        :return: A dictionary containing all the stuff we need for my-surveys
+        """
+        return  self._env.asyncio.access_endpoint('/api/1.0.0/surveys/todo/{}'.format(party_id), params=filter)

--- a/ons_ras_common/ons_rest_ci.py
+++ b/ons_ras_common/ons_rest_ci.py
@@ -1,0 +1,62 @@
+##############################################################################
+#                                                                            #
+#   Generic Routines for access to the collection instruments service        #
+#   License: MIT                                                             #
+#   Copyright (c) 2017 Crown Copyright (Office for National Statistics)      #
+#                                                                            #
+##############################################################################
+#
+#   ONSCollectionInstrument wraps access to the CI service
+#
+##############################################################################
+from os import getenv
+
+class ONSCollectionInstrument(object):
+    """
+    This class is designed to take all the work out of accessing the case service. Initially it
+    should be able to validate and log events against the case service and also query the event
+    service for specific combinations of events. (for example to determine case status)
+    """
+    def __init__(self, env):
+        self._env = env
+        self._get = '/collection-instrument-api/1.0.2/collectioninstrument/id'
+        self._upload = '/collection-instrument-api/1.0.2/survey_responses'
+
+    def activate(self):
+        """"""
+        api = getenv('ONS_API_CI', default=None)
+        if api:
+            self._env.asyncio.endpoint_init(api, self._get)
+            self._env.asyncio.endpoint_init(api, self._upload)
+
+    def get_by_id(self, instrument_id):
+        """
+        Recover an exercise by instrument_id
+
+        :param instrument_id: The id of the exercise in question
+        :return: An instrument record
+        """
+        instrument = self._env.asyncio.access_endpoint('{}/{}'.format(self._get, instrument_id))
+        if not instrument:
+            return 404, {'code': 404, 'text': 'unable to find instrument for this instrument_id'}
+
+        return 200, {'code': 200, 'instrument': instrument}
+
+    def upload(self, case_id, party_id, file_obj):
+
+        try:
+            upload = self._env.asyncio.post_upload(self._upload, case_id, file_obj)._result()
+            category = 'SUCCESSFUL_RESPONSE_UPLOAD' if upload else 'UNSUCCESSFUL_RESPONSE_UPLOAD'
+            code, msg = self._env.case_service.post_event(case_id,
+                            category=category,
+                            created_by='SYSTEM',
+                            party_id=party_id,
+                            description='Instrument response uploaded "{}"'.format(case_id))
+            if code != 200:
+                self._env.logger.error('error code = {} logging to case service: "{}"'.format(code, msg))
+
+            code = 200 if upload else 404
+            text = 'instrument uploaded' if upload else 'unable to upload instrument'
+            return code, {'code': code, 'text': text}
+        except Exception as e:
+            return 500, str(e)

--- a/ons_ras_common/ons_rest_exercise.py
+++ b/ons_ras_common/ons_rest_exercise.py
@@ -1,0 +1,38 @@
+##############################################################################
+#                                                                            #
+#   Generic Configuration tool for Micro-Service environment discovery       #
+#   License: MIT                                                             #
+#   Copyright (c) 2017 Crown Copyright (Office for National Statistics)      #
+#                                                                            #
+##############################################################################
+#
+#   ONSCase wraps routines used to access the case service
+#
+##############################################################################
+
+
+class ONSExercise(object):
+    """
+    This class is designed to take all the work out of accessing the case service. Initially it
+    should be able to validate and log events against the case service and also query the event
+    service for specific combinations of events. (for example to determine case status)
+    """
+    def __init__(self, env):
+        self._env = env
+
+    def activate(self):
+        """"""
+        pass
+
+    def get_by_id(self, exercise_id):
+        """
+        Recover an exercise by exercise_id
+
+        :param exercise_id: The id of the exercise in question
+        :return: An exercise record
+        """
+        exercise = self._env.asyncio.access_endpoint('/collectionexercises/{}'.format(exercise_id))
+        if not exercise:
+            return 404, {'code': 404, 'text': 'unable to find exercise for this exercise_id'}
+
+        return 200, {'code': 200, 'case': exercise}

--- a/requirements.txt
+++ b/requirements.txt
@@ -42,5 +42,6 @@ typing==3.6.1
 urllib3==1.21.1
 Werkzeug==0.12.2
 zope.interface==4.4.1
-
 structlog==17.2.0
+crochet==1.7.0
+

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.91'
+__version__ = '0.1.92'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.88'
+__version__ = '0.1.90'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.93'
+__version__ = '0.1.94'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.92'
+__version__ = '0.1.93'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.88'
+__version__ = '0.1.89'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.89'
+__version__ = '0.1.90'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.94'
+__version__ = '0.1.95'
 
 setup(
     name='ons_ras_common',

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-__version__ = '0.1.90'
+__version__ = '0.1.91'
 
 setup(
     name='ons_ras_common',


### PR DESCRIPTION
These changes add an async IO module and provide a generic single point of access to external endpoints. 

Why do this?
- It provides a single point of egress for accessing other micro-services
- If facilitates a single point of configuration for environment variables and routing, in whatever shape it is to take
- It provides a single point of failure in terms of trapping down'd endpoints, timeouts etc
- A number of these routines will be called by different micro-services, hence we're introducing consistency rather than letting each micro-service do things differently.
- We're moving framework / architecture centric code outside of the business logic code-base
