### PR TITLE
Removing default ONS_CRYPTO value and upping to release version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+0.4.0
+-----
+
+- Removing default value for ONS_CRYPTOKEY to ensure it doesn't silently fall back to an open value
+
 0.3.0 (unreleased)
 ------------------
 

--- a/ons_ras_common/ons_cryptographer.py
+++ b/ons_ras_common/ons_cryptographer.py
@@ -29,7 +29,7 @@ class ONSCryptographer:
         """
         Setup the required keys with values from config.ini
         """
-        key = getenv('ONS_CRYPTOKEY', self._env.get('crypto_key', 'NO_KEY'))
+        key = getenv('ONS_CRYPTOKEY')
         self._env.logger.info('Setting crypto key to "{}"'.format(key))
         self._key = sha256(key.encode('utf-8')).digest()
 

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-version = '0.3.0'
+version = '0.4.0'
 
 setup(
     name='ons_ras_common',


### PR DESCRIPTION
Only ras-collection-instrument uses this for encrypting (and decrypting) CIs in the DB.