### PR TITLE
Enable an environment variable to override a lookup even when the con…

### DIFF
--- a/ons_ras_common/ons_environment.py
+++ b/ons_ras_common/ons_environment.py
@@ -140,15 +140,13 @@ class ONSEnvironment(object):
         :param section: An optional section name, otherwise we use the environment
         :return: The value of the attribute or 'default' if not found
         """
+        value = getenv(attribute.upper(), default=None)
+        if value:
+            return value.lower() in ['yes', 'true'] if boolean else value
+
         section = section or self._env
         if section not in self._config:
             return default
-
-        value = getenv(attribute.upper(), default=None)
-        if value:
-            if not boolean:
-                return value
-            return value.lower() in ['yes', 'true']
 
         base = self._config[section]
         return base.getboolean(attribute, default) if boolean else base.get(attribute, default)

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ here = path.abspath(path.dirname(__file__))
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
-version = '0.3.0'
+version = '0.3.1'
 
 setup(
     name='ons_ras_common',

--- a/test/test_environment.py
+++ b/test/test_environment.py
@@ -1,4 +1,6 @@
 import unittest
+from unittest.mock import patch
+
 from ons_ras_common import ons_env
 from os import environ
 
@@ -6,9 +8,6 @@ ons_env.setup()
 
 
 class TestEnvironment(unittest.TestCase):
-
-    def setUp(self):
-        pass
 
     def test_default_settings_exist(self):
         enable_database = ons_env.get('enable_database', boolean=True)
@@ -33,6 +32,12 @@ class TestEnvironment(unittest.TestCase):
         environ['MY_ENV_KEY'] = 'HELLO'
         test = ons_env.get('MY_ENV_KEY')
         self.assertEqual(test, 'HELLO')
+
+    def test_environment_override_always_active(self):
+        environ['API_PORT'] = '5555'
+        a1 = ons_env.get('api_port')
+        a2 = ons_env.get('api_port', section='nonexistent')
+        self.assertEqual(a1, a2)
 
     def test_host_attribute(self):
         self.assertEqual(ons_env.host, 'localhost')


### PR DESCRIPTION
…figured environment doesn't exist in the config.ini.

This fixes the problem of looking-up a value for an environment which isn't present in the config.ini (e.g. CI).